### PR TITLE
Percentage fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,69 +6,80 @@ Calculator in HTML,CSS and JS - (c) 2023 NH (N3v1) - Use at your own risk, no wa
 
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Calculator</title>
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
-    
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
+      rel="stylesheet"
+    />
+
     <!--Import css file-->
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css" />
 
     <!--Link the index.js file-->
     <script src="index.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/decimal.js/10.3.1/decimal.min.js"></script>
-    
+
+    <!--Add the 'math.js' lib script tag-->
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/11.9.1/math.min.js"
+      integrity="sha512-lqXu8Lu4KQXMNAVo/X/3EWoRoL4aYErKld20g77Xh2NiAoFM5krIzUayEvBeVvORuFR4NWqyDqP8scYzXcguAw=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    ></script>
+
     <!--Link the manifest file-->
-    <link rel="manifest" href="manifest.webmanifest">
+    <link rel="manifest" href="manifest.webmanifest" />
+  </head>
 
-</head>
-
-<body>
-    <div id="previousExpression"></div> <!-- New div for previous expression -->
+  <body>
+    <div id="previousExpression"></div>
+    <!-- New div for previous expression -->
     <div id="resultArea"></div>
-    
-    <table>
-        <div class="heading"><span class="magic"><span class="magic-text">Calculator</span></span></div>
 
-        <tr>
-            <td onclick="appendOperation('(')">(</td>
-            <td onclick="appendOperation(')')">)</td>
-            <td onclick="appendOperation(' % ')">%</td>
-            <td onclick="deleteLast()" class="operators">DEL</td>
-        </tr>
-        <tr>
-            <td onclick="appendOperation(7)">7</td>
-            <td onclick="appendOperation(8)">8</td>
-            <td onclick="appendOperation(9)">9</td>
-            <td onclick="appendOperation(' / ')" class="operators">/</td>
-        </tr>
-        <tr>
-            <td onclick="appendOperation(4)">4</td>
-            <td onclick="appendOperation(5)">5</td>
-            <td onclick="appendOperation(6)">6</td>
-            <td onclick="appendOperation(' * ')" class="operators">x</td>
-        </tr>
-        <tr>
-            <td onclick="appendOperation(1)">1</td>
-            <td onclick="appendOperation(2)">2</td>
-            <td onclick="appendOperation(3)">3</td>
-            <td onclick="appendOperation(' + ')" class="operators">+</td>
-        </tr>
-        <tr>
-            <td onclick="appendOperation(0)">0</td>
-            <td onclick="appendDecimal('.')" class="operators">.</td>
-            <td onclick="calculateResult()" id="equalsign">=</td>
-            
-            <!--The minus operation didn't have the appendOperation function in the onclick event. 
+    <table>
+      <div class="heading">
+        <span class="magic"><span class="magic-text">Calculator</span></span>
+      </div>
+
+      <tr>
+        <td onclick="appendOperation('(')">(</td>
+        <td onclick="appendOperation(')')">)</td>
+        <td onclick="appendOperation(' % ')">%</td>
+        <td onclick="deleteLast()" class="operators">DEL</td>
+      </tr>
+      <tr>
+        <td onclick="appendOperation(7)">7</td>
+        <td onclick="appendOperation(8)">8</td>
+        <td onclick="appendOperation(9)">9</td>
+        <td onclick="appendOperation(' / ')" class="operators">/</td>
+      </tr>
+      <tr>
+        <td onclick="appendOperation(4)">4</td>
+        <td onclick="appendOperation(5)">5</td>
+        <td onclick="appendOperation(6)">6</td>
+        <td onclick="appendOperation(' * ')" class="operators">x</td>
+      </tr>
+      <tr>
+        <td onclick="appendOperation(1)">1</td>
+        <td onclick="appendOperation(2)">2</td>
+        <td onclick="appendOperation(3)">3</td>
+        <td onclick="appendOperation(' + ')" class="operators">+</td>
+      </tr>
+      <tr>
+        <td onclick="appendOperation(0)">0</td>
+        <td onclick="appendDecimal('.')" class="operators">.</td>
+        <td onclick="calculateResult()" id="equalsign">=</td>
+
+        <!--The minus operation didn't have the appendOperation function in the onclick event. 
                 After adding the appendOperation the subtraction is functioning properly. Phillip Andrews-->
-            <td onclick="appendOperation(' - ')" class="operators">-</td>
-        </tr>
+        <td onclick="appendOperation(' - ')" class="operators">-</td>
+      </tr>
     </table>
-</body>
+  </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -40,15 +40,6 @@ function appendDecimal(decimal) {
   }
 }
 
-// Assuming you've included the decimal.js library in your HTML
-
-// Assuming you've included the decimal.js library in your HTML
-
-// Convert a percentage value to a decimal
-function percentageToDecimal(percentage) {
-  return new Decimal(percentage) / 100; // Divide the percentage value by 100 to get the decimal value
-}
-
 // Calculate and display the result of the expression
 function calculateResult() {
   // Get containers for previous expression and result display
@@ -57,36 +48,14 @@ function calculateResult() {
   const resultContainer = document.getElementById("resultArea");
 
   // Get the expression from the result display
-  const calculation = resultContainer.innerHTML;
-  const splitUpCalculation = calculation.split(" "); // Split the expression into parts
+  const expression = resultContainer.innerHTML;
 
-  let newCalculation = [];
+  //Insert the current expression into the previousExpressionContainer on display
+  previousExpressionContainer.innerHTML = expression;
 
-  // Iterate through the expression parts
-  splitUpCalculation.forEach((part, index) => {
-    if (part === "%") {
-      // If the part is a percentage symbol
-      const number = splitUpCalculation[index - 1]; // Get the number before the percentage symbol
-      const nC_index = newCalculation.length - 1;
-
-      // Check if the number is already a decimal or needs conversion
-      if (typeof number === "number") {
-        newCalculation[nC_index] = number / 100; // Convert the number to a decimal
-      } else {
-        newCalculation[nC_index] = percentageToDecimal(number); // Convert the percentage value to a decimal
-      }
-      return;
-    }
-
-    newCalculation.push(part); // Push non-percentage parts to the newCalculation array
-  });
-
-  const previousExpression = splitUpCalculation.join(" "); // Join the parts back to the expression
-  previousExpressionContainer.innerHTML = previousExpression;
-
-  // Use Decimal type for calculations
-  let result = new Decimal(eval(newCalculation.join(" "))); // Evaluate the new expression
-  resultContainer.innerHTML = result.toString(); // Convert result to string for display
+  // Use the 'math.js' lib to first compile the expression and then evaluate it.
+  let result = math.compile(expression).evaluate(); // Math.js - Compile(type 'string') then Evaluate() - returns number;
+  resultContainer.innerHTML = result.toString(); // Convert result type 'number' to string for display
 }
 
 function deleteLast() {


### PR DESCRIPTION
## What this FIX solves:
1. [Issue #19](https://github.com/N3v1/Calculator/issues/19)

## Details:
### Lines [73 to 77](https://github.com/N3v1/Calculator/blob/22ad8e414d1c4b1e189f3485cc77a4b7ffa371d4/index.js#L73C6-L77C8):
* The `if` content will never run, because the `typeof` of the arg `number` will always be a `string`.
* In `else` body, the `percentageToDecimal()` function is called and then...

### Lines [48 to 50](https://github.com/N3v1/Calculator/blob/22ad8e414d1c4b1e189f3485cc77a4b7ffa371d4/index.js#L47C1-L50C2):
* The `percentageToDecimal()` function receives the `string` and the parses it with `new Decimal()`.
* `new Decimal()` returns a decimal and then the decimal is divided by  100.
* `percentageToDecimal()` then returns the quotient of that operation.

That is, the '50' as a string will trigger the `percentageToDecimal()` function that will invoke the `new Decimal()` and be divided by 100, and then returned as `0.5`, hence `100 - 0.5 = 99.5`.

### Fix:
To fix this problem I made a few changes on the code:
1. Add 'math.js' library to parse and evaluate expressions.
2. Remove library 'decimal.js'.
3. Remove `percentageToDecimal()` function.
4. Partially refactoring.